### PR TITLE
Export path to PHP's bin folder once only

### DIFF
--- a/brew.sh
+++ b/brew.sh
@@ -16,6 +16,6 @@ pecl install xdebug
 # Cleanup old downloads
 brew cleanup
 
-# Link to homebrew's php
-echo 'export PATH="/usr/local/opt/php@7.1/bin:$PATH"' >> ~/.bash_profile
-echo 'export PATH="/usr/local/opt/php@7.1/sbin:$PATH"' >> ~/.bash_profile
+# If needed override the systems' PHP with the version from the Brewfile (currently version 7.1)
+grep 'export PATH="/usr/local/opt/php@7.1/bin:$PATH"' ~/.bash_profile || echo 'export PATH="/usr/local/opt/php@7.1/bin:$PATH"' >> ~/.bash_profile
+grep 'export PATH="/usr/local/opt/php@7.1/sbin:$PATH"' ~/.bash_profile || echo 'export PATH="/usr/local/opt/php@7.1/sbin:$PATH"' >> ~/.bash_profile


### PR DESCRIPTION
Adds a `grep` check to avoid needlessly appending the export on each re-run of `brew.sh`. Keeps `~/.bash_profile` clean.