### PR TITLE
Remove obsolete global Composer tools

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,20 +54,3 @@ As an overview it installs:
  ``` bash
  brew update && brew upgrade --all
  ```
-
-
-### Additional tools installed via Composer (optional)
-
-These are additional tools and optional steps, if you work on multiple and don't have them in the Vagrant image.
-
-* Install Composer follow the instructions on https://getcomposer.org/download/ for the latest and most secure way.
-
-* Copy [`composer.json`](composer.json) from this project to Composer global config directory and install the global dependencies:
-
-``` bash
-cp composer.json ~/.composer/composer.json
-composer global install
-```
-
-* Additional useful tools:
- **PHPUnit**, **PHP Code Sniffer** and **PHP Code Style Fixer**.

--- a/composer.json
+++ b/composer.json
@@ -1,8 +1,0 @@
-{
-    "require": {
-        "clippings/composer-init": "^0.4.0",
-        "phpunit/phpunit": "^5.3",
-        "squizlabs/php_codesniffer": "^2.6",
-        "friendsofphp/php-cs-fixer": "^2.6, <2.7"
-    }
-}


### PR DESCRIPTION
We no longer use those as global installs.

The last one installed globally was PHP CS Fixer and is now being brought as a local tool again. See https://github.com/clippings/clippings/pull/4936.