### PR TITLE
Ruby installation of Brew has been deprecated

### DIFF
--- a/developer.sh
+++ b/developer.sh
@@ -4,7 +4,7 @@
 xcode-select -p 1> /dev/null || xcode-select --install
 
 # Install Brew if not installed
-command -v brew > /dev/null || /usr/bin/ruby -e "$(curl -fsSL https://raw.githubusercontent.com/Homebrew/install/master/install)"
+command -v brew > /dev/null || /bin/bash -c "$(curl -fsSL https://raw.githubusercontent.com/Homebrew/install/HEAD/install.sh)"
 
 # Update Brew and Formulae
 brew update

--- a/non-developer.sh
+++ b/non-developer.sh
@@ -4,7 +4,7 @@
 xcode-select -p 1> /dev/null || xcode-select --install
 
 # Install Brew if not installed
-command -v brew > /dev/null || /usr/bin/ruby -e "$(curl -fsSL https://raw.githubusercontent.com/Homebrew/install/master/install)"
+command -v brew > /dev/null || /bin/bash -c "$(curl -fsSL https://raw.githubusercontent.com/Homebrew/install/HEAD/install.sh)"
 
 # Update Brew and Formulaе
 brew update


### PR DESCRIPTION
Warning: The Ruby Homebrew installer is now deprecated and has been rewritten in
Bash.  That's why we must migrate to the following command:
/bin/bash -c "$(curl -fsSL https://raw.githubusercontent.com/Homebrew/install/HEAD/install.sh)"